### PR TITLE
ISSUE-4: add opendkim.body() and finish opendkim.eom()

### DIFF
--- a/src/opendkim.h
+++ b/src/opendkim.h
@@ -27,6 +27,7 @@ class OpenDKIM : public Nan::ObjectWrap {
     // Processing methods
     static NAN_METHOD(Header);
     static NAN_METHOD(EOH);
+    static NAN_METHOD(Body);
     static NAN_METHOD(EOM);
 
     // Signing methods

--- a/test/src/processing.js
+++ b/test/src/processing.js
@@ -114,6 +114,97 @@ test('test eoh method works after header calls', t => {
   }
 });
 
+test('test body method with no argument', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.body();
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): Wrong number of arguments');
+  }
+});
+
+test('test body method with numeric argument', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.body(1);
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): Argument should be an object');
+  }
+});
+
+test('test body method with string argument', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.body('test');
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): Argument should be an object');
+  }
+});
+
+test('test body method with missing body arg', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.body({
+      // nothing
+    });
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): body is undefined');
+  }
+});
+
+test('test body method with missing length arg', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    var body = 'This is a test';
+    opendkim.body({
+      body: body
+    });
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): length must be defined and non-zero');
+  }
+});
+
+test('test body needs context', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    var body = 'This is a test';
+    opendkim.body({
+      body: body,
+      length: body.length
+    });
+    t.fail();
+  } catch (err) {
+    t.is(err.message, 'body(): sign() or verify() must be called first');
+  }
+});
+
+test('test body method works after header and eoh', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.verify({id: undefined});
+    var header = 'From: <herp@derp.com>';
+    opendkim.header({
+      header: header,
+      length: header.length
+    });
+    opendkim.eoh();
+    var body = 'this is a test';
+    opendkim.body({
+      body: body,
+      length: body.length
+    });
+    t.pass();
+  } catch (err) {
+    console.log(err);
+    t.fail();
+  }
+});
+
 test('test eom needs context', t => {
   try {
     var opendkim = new OpenDKIM();
@@ -121,5 +212,28 @@ test('test eom needs context', t => {
     t.fail();
   } catch (err) {
     t.is(err.message, 'eom(): sign() or verify(), then body() must be called first');
+  }
+});
+
+test('test eom method works after header, eoh, and body calls', t => {
+  try {
+    var opendkim = new OpenDKIM();
+    opendkim.verify({id: undefined});
+    var header = 'From: <herp@derp.com>';
+    opendkim.header({
+      header: header,
+      length: header.length
+    });
+    opendkim.eoh();
+    var body = 'this is a test';
+    opendkim.body({
+      body: body,
+      length: body.length
+    });
+    opendkim.eom();
+    t.pass();
+  } catch (err) {
+    console.log(err);
+    t.fail();
   }
 });


### PR DESCRIPTION
This PR adds the interface for `opendkim.body()` and tests for the clean path.  That is, it tests for the path where there are no DKIM headers.  I will probably add a test-only PR after chunk that tests for differing states of DKIM signed messages.

original issue here:
https://github.com/godsflaw/node-opendkim/issues/4