### PR TITLE
ISSUE-12: change the default signalg for sign to sha256

### DIFF
--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -361,17 +361,15 @@ NAN_METHOD(OpenDKIM::Sign) {
     bodycanon_alg = DKIM_CANON_RELAXED;
   }
 
-  // signalg
+  // signalg, the default is now sha256 due to weakness in sha1
   char *signalg = NULL;
-  if (!_value_to_char(info[0], "signalg", &signalg)) {
-    Nan::ThrowTypeError("sign(): signalg is undefined");
-    return;
-  }
-  for (int i = 0 ; signalg[i] != '\0'; i++) signalg[i] = tolower(signalg[i]);
+  dkim_alg_t sign_alg = DKIM_SIGN_RSASHA256;
+  if (_value_to_char(info[0], "signalg", &signalg)) {
+    for (int i = 0 ; signalg[i] != '\0'; i++) signalg[i] = tolower(signalg[i]);
 
-  dkim_alg_t sign_alg = DKIM_SIGN_RSASHA1;
-  if (strcmp(signalg, "sha256") == 0) {
-    sign_alg = DKIM_SIGN_RSASHA256;
+    if (strcmp(signalg, "sha1") == 0) {
+      sign_alg = DKIM_SIGN_RSASHA1;
+    }
   }
 
   // length

--- a/test/signing/00-sign.js
+++ b/test/signing/00-sign.js
@@ -102,23 +102,6 @@ test('test sign method with missing bodycanon arg', t => {
   }
 });
 
-test('test sign method with missing signalg arg', t => {
-  try {
-    var opendkim = new OpenDKIM();
-    opendkim.sign({
-      id: undefined,
-      secretkey: 'testkey',
-      selector: 'a1b2c3',
-      domain: 'example.com',
-      hdrcanon: 'relaxed',
-      bodycanon: 'relaxed'
-    });
-    t.fail();
-  } catch (err) {
-    t.is(err.message, 'sign(): signalg is undefined');
-  }
-});
-
 test('test sign method works as object with correct args', t => {
   try {
     var opendkim = new OpenDKIM();
@@ -129,7 +112,7 @@ test('test sign method works as object with correct args', t => {
       domain: 'example.com',
       hdrcanon: 'relaxed',
       bodycanon: 'relaxed',
-      signalg: 'sha256',
+      signalg: 'sha256',     // default is sha256
       length: -1
     });
     t.pass();


### PR DESCRIPTION
Given the recent vulnerabilities in `sha1`, we should make the default `signalg` `sha256` for the `opendkim.sign()` function.  This is related to #12.