### PR TITLE
ISSUE-1: fixing compile warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-opendkim",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "node.js language binding for libopendkim",
   "license": "MIT",
   "repository": "godsflaw/node-opendkim",

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -52,39 +52,39 @@ OpenDKIM::~OpenDKIM() {
 
 NAN_MODULE_INIT(OpenDKIM::Init) {
   v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-  tpl->SetClassName(Nan::New("OpenDKIM").ToLocalChecked());
+  tpl->SetClassName(Nan::New<String>("OpenDKIM").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Administration methods
-  SetPrototypeMethod(tpl, "flush_cache", FlushCache);
+  Nan::SetPrototypeMethod(tpl, "flush_cache", FlushCache);
 
   // Processing methods
-  SetPrototypeMethod(tpl, "header", Header);
-  SetPrototypeMethod(tpl, "eoh", EOH);
-  SetPrototypeMethod(tpl, "body", Body);
-  SetPrototypeMethod(tpl, "eom", EOM);
-  SetPrototypeMethod(tpl, "chunk", Chunk);
-  SetPrototypeMethod(tpl, "chunk_end", ChunkEnd);
+  Nan::SetPrototypeMethod(tpl, "header", Header);
+  Nan::SetPrototypeMethod(tpl, "eoh", EOH);
+  Nan::SetPrototypeMethod(tpl, "body", Body);
+  Nan::SetPrototypeMethod(tpl, "eom", EOM);
+  Nan::SetPrototypeMethod(tpl, "chunk", Chunk);
+  Nan::SetPrototypeMethod(tpl, "chunk_end", ChunkEnd);
 
   // Signing methods
-  SetPrototypeMethod(tpl, "sign", Sign);
+  Nan::SetPrototypeMethod(tpl, "sign", Sign);
 
   // Verifying methods
-  SetPrototypeMethod(tpl, "verify", Verify);
-  SetPrototypeMethod(tpl, "get_signature", GetSignature);
-  SetPrototypeMethod(tpl, "sig_getidentity", SigGetIdentity);
-  SetPrototypeMethod(tpl, "sig_getdomain", SigGetDomain);
-  SetPrototypeMethod(tpl, "sig_getselector", SigGetSelector);
+  Nan::SetPrototypeMethod(tpl, "verify", Verify);
+  Nan::SetPrototypeMethod(tpl, "get_signature", GetSignature);
+  Nan::SetPrototypeMethod(tpl, "sig_getidentity", SigGetIdentity);
+  Nan::SetPrototypeMethod(tpl, "sig_getdomain", SigGetDomain);
+  Nan::SetPrototypeMethod(tpl, "sig_getselector", SigGetSelector);
 
   // Utility methods
-  SetPrototypeMethod(tpl, "get_option", GetOption);
-  SetPrototypeMethod(tpl, "set_option", SetOption);
+  Nan::SetPrototypeMethod(tpl, "get_option", GetOption);
+  Nan::SetPrototypeMethod(tpl, "set_option", SetOption);
 
-  constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  constructor().Reset(tpl->GetFunction());
   Nan::Set(
     target,
     Nan::New("OpenDKIM").ToLocalChecked(),
-    Nan::GetFunction(tpl).ToLocalChecked()
+    tpl->GetFunction()
   );
 }
 
@@ -95,7 +95,7 @@ NAN_METHOD(OpenDKIM::New) {
     info.GetReturnValue().Set(info.This());
   } else {
     v8::Local<v8::Function> cons = Nan::New(constructor());
-    info.GetReturnValue().Set(cons->NewInstance());
+    info.GetReturnValue().Set(Nan::NewInstance(cons).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
```
% node-gyp rebuild 
gyp info it worked if it ends with ok
gyp info using node-gyp@3.5.0
gyp info using node@8.1.2 | darwin | x64
gyp info spawn /usr/local/bin/python2
gyp info spawn args [ '/usr/local/lib/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/godsflaw/src/node-opendkim/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/usr/local/lib/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/godsflaw/.node-gyp/8.1.2/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/godsflaw/.node-gyp/8.1.2',
gyp info spawn args   '-Dnode_gyp_dir=/usr/local/lib/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=node.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/godsflaw/src/node-opendkim',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CXX(target) Release/obj.target/opendkim/src/opendkim.o
  SOLINK_MODULE(target) Release/opendkim.node
gyp info ok 
bateman <16:15:46>% npm test -- --verbose

> node-opendkim@0.0.3 test /Users/godsflaw/src/node-opendkim
> xo && nyc ava "--verbose"

(node:9236) Warning: process.on(SIGPROF) is reserved while debugging

  ✔ 03-utility › 04-tmpdir › check default is empty
  ✔ 03-utility › 04-tmpdir › test that data is never empty on set (101ms)
  ✔ 03-utility › 04-tmpdir › test get/set
  ✔ 00-administration › 01-flush-cache › test flush_cache with no active cache
  ✔ 04-verifying › 05-message-bad-timestamp-negative › test message with bad timestamp (negative)
  ✔ 02-signing › 00-sign › test sign method with no argument
  ✔ 02-signing › 00-sign › test sign method with numeric argument
  ✔ 02-signing › 00-sign › test sign method with string argument
  ✔ 02-signing › 00-sign › test sign method with missing secretkey arg
  ✔ 02-signing › 00-sign › test sign method with missing selector arg
  ✔ 02-signing › 00-sign › test sign method with missing domain arg
  ✔ 02-signing › 00-sign › test sign method with missing hdrcanon arg
  ✔ 02-signing › 00-sign › test sign method with missing bodycanon arg
  ✔ 02-signing › 00-sign › test sign method works as object with correct args
  ✔ 00-administration › 00-base-object › new OpenDKIM is an empty object
  ✔ 04-verifying › 06-message-bad-timestamp-bogus › test message with bad timestamp (bogus)
  ✔ 03-utility › 03-query-info › check default is empty
  ✔ 03-utility › 03-query-info › test that data is never empty on set
  ✔ 03-utility › 03-query-info › test get/set
  ✔ 03-utility › 01-set-options › test with no argument
  ✔ 03-utility › 01-set-options › test with numeric argument
  ✔ 03-utility › 01-set-options › test with string argument
  ✔ 03-utility › 01-set-options › test with missing option arg
  ✔ 03-utility › 01-set-options › test with missing data
  ✔ 03-utility › 01-set-options › test with missing length
  ✔ 03-utility › 01-set-options › test with invalid option
  ✔ 03-utility › 01-set-options › get/set default for DKIM_OPTS_QUERYMETHOD
  ✔ 03-utility › 00-get-option › test with no argument
  ✔ 03-utility › 00-get-option › test with numeric argument
  ✔ 03-utility › 00-get-option › test with string argument
  ✔ 03-utility › 00-get-option › test with missing option arg
  ✔ 03-utility › 00-get-option › test with invalid option
  ✔ 03-utility › 00-get-option › check default for DKIM_OPTS_QUERYMETHOD
  ✔ 01-processing › 00-header › test header method with no argument
  ✔ 01-processing › 00-header › test header method with numeric argument
  ✔ 01-processing › 00-header › test header method with string argument
  ✔ 01-processing › 00-header › test header method with missing header arg
  ✔ 01-processing › 00-header › test header method with missing length arg
  ✔ 01-processing › 00-header › test header needs context
  ✔ 01-processing › 00-header › test header method works as object with correct args
  ✔ 01-processing › 05-chunk-end › test chunk_end needs context
  ✔ 01-processing › 05-chunk-end › test chunk_end without calling chunk
  ✔ 01-processing › 05-chunk-end › test chunk_end works after chunk
  ✔ 01-processing › 03-eom › test eom needs context
  ✔ 01-processing › 03-eom › test eom works after header, eoh, and body calls
  ✔ 04-verifying › 00-verify › test verify method with no argument
  ✔ 04-verifying › 00-verify › test verify method with numeric argument
  ✔ 04-verifying › 00-verify › test verify method with string argument
  ✔ 04-verifying › 00-verify › test verify method works as object with correct args
  ✔ 01-processing › 01-eoh › test eoh needs context
  ✔ 04-verifying › 04-message-bad-timestamp-empty › test message with bad timestamp (empty)
  ✔ 01-processing › 04-chunk › test chunk with no argument
  ✔ 01-processing › 04-chunk › test chunk with numeric argument
  ✔ 01-processing › 04-chunk › test chunk with string argument
  ✔ 01-processing › 04-chunk › test chunk with missing chunk arg
  ✔ 01-processing › 04-chunk › test chunk with missing length arg
  ✔ 01-processing › 04-chunk › test chunk needs context
  ✔ 01-processing › 04-chunk › test chunk works
  ✔ 01-processing › 04-chunk › test many chunks
  ✔ 01-processing › 02-body › test body method with no argument
  ✔ 01-processing › 02-body › test body method with numeric argument
  ✔ 01-processing › 02-body › test body method with string argument
  ✔ 01-processing › 02-body › test body method with missing body arg
  ✔ 01-processing › 02-body › test body method with missing length arg
  ✔ 01-processing › 02-body › test body needs context
  ✔ 04-verifying › 04-message-bad-timestamp-future › test message with bad timestamp (future)
  ✔ 03-utility › 02-query-method › check default is DKIM_QUERY_DNS
  ✔ 03-utility › 02-query-method › test get/set
  ✔ 03-utility › 02-query-method › throws error on invalid method
  ✔ 04-verifying › 03-message-bad-must-me-signed-list › test message with bad signature list (extra CC header)
  ✔ 04-verifying › 16-message-bad-altered-body › test message with an altered body
  ✔ 04-verifying › 01-message-good › test good message chunk (103ms)
  ✔ 04-verifying › 01-message-good › test good message multi-chunk
  ✔ 04-verifying › 09-message-bad-missing-signed-header › test message with missing signed header
  ✔ 04-verifying › 17-message-bad-malformed-signature › test message with malformed signature
  ✔ 04-verifying › 07-message-bad-extra-signature-spaces › test message with bad extra signature spaces (102ms)
  ✔ 04-verifying › 15-message-bad-missing-from › test message with missing from header
  ✔ 04-verifying › 10-message-bad-malformed › test malformed message
  ✔ 04-verifying › 02-message-bad-timestamp › test message with bad timestamp
  ✔ 04-verifying › 13-message-bad-missing-bh-tag › test message with missing bh tag
  ✔ 04-verifying › 14-message-bad-bogus-from › test message with bogus from header
  ✔ 04-verifying › 12-message-bad-sigalg › test message with bad signature algorithm
  ✔ 04-verifying › 20-message-bad-lacking-h › test message with h= lacking required headers
  ✔ 04-verifying › 18-message-bad-mismatched-i-d › test message with mismatched i= and d=
  ✔ 04-verifying › 11-message-bad-header-canonicalization › test message with bad header canonicalization
  ✔ 04-verifying › 08-message-bad-no-key › test message with no key
  ✔ 04-verifying › 28-message-no-signature › test no signature message chunk
  ✔ 04-verifying › 28-message-no-signature › test no signature message multi-chunk
  ✔ 04-verifying › 28-message-no-signature › test no signature through header(), eoh(), body(), and eom()
  ✔ 04-verifying › 21-message-bad-oversized-l › test message with oversized l=
  ✔ 04-verifying › 26-sig-getdomain › test sig_getdomain before verify
  ✔ 04-verifying › 26-sig-getdomain › test sig_getdomain before chunk_end
  ✔ 04-verifying › 26-sig-getdomain › test sig_getdomain after chunk
  ✔ 04-verifying › 26-sig-getdomain › test a more pedantic sig_getdomain
  ✔ 04-verifying › 27-sig-getselector › test sig_getselector before verify
  ✔ 04-verifying › 27-sig-getselector › test sig_getselector before chunk_end
  ✔ 04-verifying › 27-sig-getselector › test sig_getselector after chunk
  ✔ 04-verifying › 27-sig-getselector › test a more pedantic sig_getselector
  ✔ 04-verifying › 22-message-bad-body-canonicalization › test message with bad body canonicalization
  ✔ 04-verifying › 23-message-bad-signature-version › test message with bad signature version
  ✔ 04-verifying › 24-get-signature › test get_signature before verify
  ✔ 04-verifying › 24-get-signature › test get_signature before chunk_end
  ✔ 04-verifying › 24-get-signature › test get_signature after chunk
  ✔ 04-verifying › 25-sig-getidentity › test sig_getidentity before verify
  ✔ 04-verifying › 25-sig-getidentity › test sig_getidentity before chunk_end
  ✔ 04-verifying › 25-sig-getidentity › test sig_getidentity after chunk
  ✔ 04-verifying › 25-sig-getidentity › test a more pedantic sig_getidentity
  ✔ 04-verifying › 19-message-bad-missing-h-signature › test message with missing h=
  ✔ 01-processing › 01-eoh › test eoh method works after header calls (1.7s)
  ✔ 01-processing › 02-body › test body method works after header and eoh (2.7s)

  110 tests passed [16:17:52]

----------------|----------|----------|----------|----------|----------------|
File            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------|----------|----------|----------|----------|----------------|
 node-opendkim/ |      100 |      100 |      100 |      100 |                |
  index.js      |      100 |      100 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
All files       |      100 |      100 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
```