### PR TITLE
ISSUE-39: fixes usage of dkim_init() and dkim_close()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-opendkim",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "node.js language binding for libopendkim",
   "license": "MIT",
   "repository": "godsflaw/node-opendkim",

--- a/src/opendkim.h
+++ b/src/opendkim.h
@@ -116,7 +116,6 @@ class OpenDKIM : public Nan::ObjectWrap {
 
     // private variables
     DKIM *dkim;
-    DKIM_LIB *dkim_lib;
     DKIM_SIGINFO *sig;
 };
 


### PR DESCRIPTION
Turns out, we only need to initialize the library once according to the docs.  Calling dkim_close() causes openssl's EVM to clear, which causes other usages of that memory by openssl in other parts of the running program to fail.

In this particular case, we can see node.js's internal use of openssl in the crypto module failing to find support the digest algorithm 'md5'.  This is because at any given time, the refcount may have reached 0 in libopendkim, and we may have removed the memory structure for openssl.