### PR TITLE
ISSUE-44: fix npm install not compiling code in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ ADD test ${LOCALDIR}/test
 # install deps
 RUN apk upgrade --update && \
   apk add --no-cache --virtual .gyp python make g++ opendkim-dev && \
-  npm install -g node-gyp && \
-  apk del .gyp python make g++
+  npm install -g node-gyp
 
 # install codebase
 WORKDIR "${LOCALDIR}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ ADD test ${LOCALDIR}/test
 # install deps
 RUN apk upgrade --update && \
   apk add --no-cache --virtual .gyp python make g++ opendkim-dev && \
-  npm install -g node-gyp
+  npm install -g node-gyp && \
+  apk del .gyp python make g++
 
 # install codebase
-RUN (cd ${LOCALDIR} ; npm install ; node-gyp rebuild)
+WORKDIR "${LOCALDIR}"
+RUN npm install
 
 # startup any services
-WORKDIR "${LOCALDIR}"
 CMD ["tail", "-f", "readme.md"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk upgrade --update && \
 
 # install codebase
 WORKDIR "${LOCALDIR}"
-RUN npm install
+RUN npm install --unsafe-perm
 
 # startup any services
 CMD ["tail", "-f", "readme.md"]

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "keywords": [
     "cli-app",
-    "cli",
-    ""
+    "cli"
   ],
   "dependencies": {
     "meow": "^3.7.0",

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 > node.js native language binding to libopendkim
 
 
-## Install/Test (locally)
+## Install/Test Locally (from source)
 
 ```
 git clone git@github.com:godsflaw/node-opendkim.git
@@ -13,7 +13,7 @@ npm test -- --verbose
 
 ```
 
-## Install/Test (npm)
+## Install Locally (npm)
 
 ```
 npm install --save node-opendkim
@@ -28,7 +28,7 @@ npm install --global node-opendkim
 ## Compile (Development)
 
 ```
-node-gyp clean ; node-gyp configure ; node-gyp build
+node-gyp rebuild
 
 ```
 


### PR DESCRIPTION
fixes #44 by adding `--unsafe-perm` to the install