### PR TITLE
ISSUE-20: implements sig_geterrorstr

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,10 +94,9 @@ try {
 * [opendkim.get_signature()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.get_signature()): sets the signature info handle.
 * [opendkim.sig_getidentity()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getidentity()): get the identity from the signature handle.
 * [opendkim.sig_getdomain()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()): get the domain from the signature handle.
-* [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
-* [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): get the error value for a specific signature. 
+* [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): Retrieve the error code associated with a rejected/disqualified signature.
 * [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified by the error code.
-
+* [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
 
 ## API Utility
 * [opendkim.query_info()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.query_info()): get/set query info.

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ try {
 * [opendkim.sig_getdomain()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()): get the domain from the signature handle.
 * [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
 * [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): get the error value stored for a specific message. 
+* [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified error code.
 
 
 ## API Utility

--- a/readme.md
+++ b/readme.md
@@ -95,8 +95,8 @@ try {
 * [opendkim.sig_getidentity()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getidentity()): get the identity from the signature handle.
 * [opendkim.sig_getdomain()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()): get the domain from the signature handle.
 * [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
-* [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): get the error value stored for a specific message. 
-* [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified error code.
+* [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): get the error value for a specific signature. 
+* [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified by the error code.
 
 
 ## API Utility

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -703,7 +703,7 @@ NAN_METHOD(OpenDKIM::GetOption) {
       opt,
       &data,
       sizeof(data)
-   );
+    );
 
     if (statp != DKIM_STAT_OK) {
       throw_error(statp);

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -1,4 +1,4 @@
-#include "opendkim.h"
+e#include "opendkim.h"
 #include <stdio.h>
 #include <unistd.h>    // TODO(godsflaw): port for windows?
 
@@ -408,25 +408,17 @@ NAN_METHOD(OpenDKIM::SigGetError) {
   info.GetReturnValue().Set(Nan::New<v8::Int32>(data));
 }
 
-NAN_METHOD(OpenDKIM::SigGetErrorStr) {
-  int errorcode = 0;
-  char* errorstr = NULL;
-  int errorlen = 0;
-
-  if (info.Length() != 1) {
-    Nan::ThrowTypeError("sig_geterrorstr(): Wrong number of arguments");
-    goto finish_sig_geterrorstr;
-  }
-
-  errorcode = info[0]->NumberValue(); 
-  errorlen = strlen(dkim_sig_geterrorstr(errorcode)) + 1;
-  errorstr = new char[errorlen];
-
-  strcpy(errorstr, dkim_sig_geterrorstr(errorcode));
-  info.GetReturnValue().Set(Nan::New<v8::String>(errorstr).ToLocalChecked());
-
-  finish_sig_geterrorstr:
-    _safe_free(&errorstr);
+NAN_METHOD(OpenDKIM::SigGetErrorStr) {                                          
+  const char *errorstr = NULL;                                                  
+                                                                                
+  if (info.Length() != 1) {                                                     
+    Nan::ThrowTypeError("sig_geterrorstr(): Wrong number of arguments");        
+    return;                                                                     
+  }                                                                             
+                                                                                
+  errorstr = dkim_sig_geterrorstr(info[0]->NumberValue());                                               
+                                                                                
+  info.GetReturnValue().Set(Nan::New<v8::String>(errorstr).ToLocalChecked());   
 }
 
 NAN_METHOD(OpenDKIM::Chunk) {

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -1,4 +1,4 @@
-e#include "opendkim.h"
+#include "opendkim.h"
 #include <stdio.h>
 #include <unistd.h>    // TODO(godsflaw): port for windows?
 

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -75,6 +75,7 @@ NAN_MODULE_INIT(OpenDKIM::Init) {
   Nan::SetPrototypeMethod(tpl, "sig_getdomain", SigGetDomain);
   Nan::SetPrototypeMethod(tpl, "sig_getselector", SigGetSelector);
   Nan::SetPrototypeMethod(tpl, "sig_geterror", SigGetError);
+  Nan::SetPrototypeMethod(tpl, "sig_geterrorstr", SigGetErrorStr);
 
   // Utility methods
   Nan::SetPrototypeMethod(tpl, "get_option", GetOption);
@@ -407,6 +408,27 @@ NAN_METHOD(OpenDKIM::SigGetError) {
   info.GetReturnValue().Set(Nan::New<v8::Int32>(data));
 }
 
+NAN_METHOD(OpenDKIM::SigGetErrorStr) {
+  int errorcode = 0;
+  char* errorstr = NULL;
+  int errorlen = 0;
+
+  if (info.Length() != 1) {
+    Nan::ThrowTypeError("sig_geterrorstr(): Wrong number of arguments");
+    goto finish_sig_geterrorstr;
+  }
+
+  errorcode = info[0]->NumberValue(); 
+  errorlen = strlen(dkim_sig_geterrorstr(errorcode)) + 1;
+  errorstr = new char[errorlen];
+
+  strcpy(errorstr, dkim_sig_geterrorstr(errorcode));
+  info.GetReturnValue().Set(Nan::New<v8::String>(errorstr).ToLocalChecked());
+
+  finish_sig_geterrorstr:
+    _safe_free(&errorstr);
+}
+
 NAN_METHOD(OpenDKIM::Chunk) {
   OpenDKIM* obj = Nan::ObjectWrap::Unwrap<OpenDKIM>(info.Holder());
   DKIM_STAT statp = DKIM_STAT_OK;
@@ -450,7 +472,8 @@ NAN_METHOD(OpenDKIM::Chunk) {
 
   finish_chunk:
     _safe_free(&message);
-    info.GetReturnValue().Set(info.This());
+
+  info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(OpenDKIM::ChunkEnd) {
@@ -680,7 +703,7 @@ NAN_METHOD(OpenDKIM::GetOption) {
       opt,
       &data,
       sizeof(data)
-    );
+   );
 
     if (statp != DKIM_STAT_OK) {
       throw_error(statp);

--- a/src/opendkim.h
+++ b/src/opendkim.h
@@ -47,6 +47,7 @@ class OpenDKIM : public Nan::ObjectWrap {
     static NAN_METHOD(SigGetDomain);
     static NAN_METHOD(SigGetSelector);
     static NAN_METHOD(SigGetError);
+    static NAN_METHOD(SigGetErrorStr);
 
     // Utility methods
     static NAN_METHOD(GetOption);

--- a/test/04-verifying/30-sig-geterrorstr.js
+++ b/test/04-verifying/30-sig-geterrorstr.js
@@ -1,0 +1,66 @@
+import test from 'ava';
+
+var OpenDKIM = require('../../');
+var Messages = require('../fixtures/messages');
+
+var messages = new Messages();
+
+test('test sig_geterrorstr with good message', t => {
+  try {
+    var opendkim = new OpenDKIM();
+
+    opendkim.query_method('DKIM_QUERY_FILE');
+    opendkim.query_info('../fixtures/testkeys');
+
+    opendkim.verify({id: undefined});
+    opendkim.chunk({
+      message: messages.good,
+      length: messages.good.length
+    });
+    opendkim.chunk_end();
+    var error = opendkim.sig_geterrorstr(opendkim.sig_geterror());
+    t.is(error, 'no signature error');
+  } catch (err) {
+    console.log(err);
+    t.fail();
+  }
+});
+
+test('test sig_geterror with bad_sigalg message', t => {
+  var opendkim = new OpenDKIM();
+  try {
+    opendkim.query_method('DKIM_QUERY_FILE');
+    opendkim.query_info('../fixtures/testkeys');
+
+    opendkim.verify({id: undefined});
+    opendkim.chunk({
+      message: messages.bad_sigalg,
+      length: messages.bad_sigalg.length
+    });
+    opendkim.chunk_end();
+    t.fail();
+  } catch (err) {
+    var error = opendkim.sig_geterrorstr(opendkim.sig_geterror());
+    t.is(error, 'signature algorithm invalid');
+  }
+});
+
+test('test sig_geterror with bad_signature_version message', t => {
+  var opendkim = new OpenDKIM();
+  try {
+    opendkim.query_method('DKIM_QUERY_FILE');
+    opendkim.query_info('../fixtures/testkeys');
+
+    opendkim.verify({id: undefined});
+    opendkim.chunk({
+      message: messages.bad_signature_version,
+      length: messages.bad_signature_version.length
+    });
+    opendkim.chunk_end();
+    t.fail();
+  } catch (err) {
+    var error = opendkim.sig_geterrorstr(opendkim.sig_geterror());
+    t.is(error, 'unsupported signature version');
+  }
+});
+


### PR DESCRIPTION
# Description
This PR implements `sig_geterrorstr()`. This function must be passed an error code from `sig_geterror()` , and it will return a string describing that error code.

# Contribution Checklist

- [x] first commit title starts with 'ISSUE-N:'
- [x] code approved
- [x] tests approved
- [x] documentation approved
- [x] fixes #20

### Link to gist documentation
https://gist.github.com/desttinghim/01244dd228b48c3c1c028c1da30bbec8
