### PR TITLE
ISSUE-3: Make eom() chainable by default

### DIFF
--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -224,6 +224,7 @@ NAN_METHOD(OpenDKIM::Body) {
 NAN_METHOD(OpenDKIM::EOM) {
   // TODO(godsflaw): perhaps expose this in node.js
   bool testkey = false;
+  bool returntest = false;
   OpenDKIM* obj = Nan::ObjectWrap::Unwrap<OpenDKIM>(info.Holder());
   DKIM_STAT statp = DKIM_STAT_OK;
 
@@ -234,6 +235,14 @@ NAN_METHOD(OpenDKIM::EOM) {
     return;
   }
 
+  if (info.Length() > 0) {
+     if (!info[0]->IsObject()) {
+        Nan::ThrowTypeError("eom(): Argument should be an object");
+     } else {
+        returntest = _value_to_bool(info[0], "testkey"); 
+     }
+  }
+
   statp = dkim_eom(obj->dkim, &testkey);
 
   // Test for error and throw an exception back to js.
@@ -242,7 +251,12 @@ NAN_METHOD(OpenDKIM::EOM) {
     return;
   }
 
-  info.GetReturnValue().Set(Nan::New<v8::Boolean>((testkey ? true : false)));
+  // success
+  if (returntest) {
+     info.GetReturnValue().Set(Nan::New<v8::Boolean>((testkey ? true : false)));
+  } else {
+     info.GetReturnValue().Set(info.This());
+  }
 }
 
 NAN_METHOD(OpenDKIM::GetSignature) {

--- a/test/01-processing/03-eom.js
+++ b/test/01-processing/03-eom.js
@@ -45,3 +45,68 @@ test('test eom works after header, eoh, and body calls', t => {
     t.fail();
   }
 });
+
+test('test eom chaining', t => {
+  try {
+    var opendkim = new OpenDKIM();
+
+    opendkim.query_method('DKIM_QUERY_FILE');
+    opendkim.query_info('../fixtures/testkeys');
+
+    opendkim.verify({id: undefined});
+    var header = messages.good.substring(0, messages.good.indexOf('\r\n\r\n'));
+    var body = messages.good.substring(messages.good.indexOf('\r\n\r\n') + 4);
+    var headers = header.replace(/\r\n\t/g, ' ').split(/\r\n/);
+    for (var i = 0; i < headers.length; i++) {
+      var line = headers[i];
+      opendkim.header({
+        header: line,
+        length: line.length
+      });
+    }
+    opendkim.eoh();
+    opendkim.body({
+      body: body,
+      length: body.length
+    });
+    opendkim.eom().sig_getdomain();
+    t.pass();
+  } catch (err) {
+    console.log(err);
+    t.fail();
+  }
+});
+
+test('test eom testkey', t => {
+  try {
+    var opendkim = new OpenDKIM();
+
+    opendkim.query_method('DKIM_QUERY_FILE');
+    opendkim.query_info('../fixtures/testkeys');
+
+    opendkim.verify({id: undefined});
+    var header = messages.good.substring(0, messages.good.indexOf('\r\n\r\n'));
+    var body = messages.good.substring(messages.good.indexOf('\r\n\r\n') + 4);
+    var headers = header.replace(/\r\n\t/g, ' ').split(/\r\n/);
+    for (var i = 0; i < headers.length; i++) {
+      var line = headers[i];
+      opendkim.header({
+        header: line,
+        length: line.length
+      });
+    }
+    opendkim.eoh();
+    opendkim.body({
+      body: body,
+      length: body.length
+    });
+    var istest = opendkim.eom({testkey: true});
+    if (!istest) { // this is a test
+      t.fail();
+    }
+    t.pass();
+  } catch (err) {
+    console.log(err);
+    t.fail();
+  }
+});


### PR DESCRIPTION
* Passing {testkey: true} to eom() uses its previous behavior
* Added a test for chaining and for testkey

# Description
This changes the eom() function to return the opendkim object by default, which can be overridden by passing `{testkey: true}` in as a parameter.

# Contribution Checklist

- [x] first commit title starts with 'ISSUE-N:'
- [x] code approved
- [x] tests approved
- [x] documentation approved
- [x] fixes #3 

### Link to gist documentation (will be manually added to the wiki)
https://gist.github.com/desttinghim/c1cfd6c112e368e67d7d874750945cc5
