### PR TITLE
ISSUE-67: version bump 0.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,8 +323,8 @@ OpenDKIM.prototype.get_signature = function () {
   return this.native_get_signature();
 };
 
-OpenDKIM.prototype.ohdrs = function (obj) {
-  return this.native_ohdrs(obj);
+OpenDKIM.prototype.ohdrs = function () {
+  return this.native_ohdrs();
 };
 
 OpenDKIM.prototype.sig_getcanonlen = function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-opendkim",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-opendkim",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "node.js language binding for libopendkim",
   "license": "MIT",
   "repository": "godsflaw/node-opendkim",

--- a/readme.md
+++ b/readme.md
@@ -126,12 +126,12 @@ function verify(message, callback) {
 * [opendkim.lib_feature()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.lib_feature()): Check for supported features.
 
 ## API Processing
+* [opendkim.chunk()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk()): Process a message chunk.
+* [opendkim.chunk_end()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk_end()): called when done with chunk.
 * [opendkim.header()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.header()): Process a header.
 * [opendkim.eoh()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.eoh()): Identify end of headers.
 * [opendkim.body()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.body()): Process a body chunk.
 * [opendkim.eom()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.eom()): Identify end of message.
-* [opendkim.chunk()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk()): Process a message chunk.
-* [opendkim.chunk_end()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk_end()): called when done with chunk.
 
 ## API Signing
 * [opendkim.sign()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sign()): get ready to sign a message.
@@ -142,14 +142,14 @@ function verify(message, callback) {
 * [opendkim.tmpdir()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.tmpdir()): get/set tmp dir.
 
 ## API Verifying
-* [opendkim.verify()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.verify()): get ready to verify a message.
 * [opendkim.get_signature()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.get_signature()): sets the signature info handle.
-* [opendkim.sig_getidentity()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getidentity()): get the identity from the signature handle.
+* [opendkim.sig_getcanonlen()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getcanonlen()): get the canonicalized message length from the signature handle and message.
 * [opendkim.sig_getdomain()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()): get the domain from the signature handle.
 * [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): Retrieve the error code associated with a rejected/disqualified signature.
 * [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified by the error code.
+* [opendkim.sig_getidentity()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getidentity()): get the identity from the signature handle.
 * [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
-* [opendkim.sig_getcanonlen()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getcanonlen()): get the canonicalized message length from the signature handle and message.
+* [opendkim.verify()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.verify()): get ready to verify a message.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ function verify(message, callback) {
 
 ## API Verifying
 * [opendkim.get_signature()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.get_signature()): sets the signature info handle.
+* [opendkim.ohdrs()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.ohdrs()): Retrieve the original header set from the "z=" tag in a received signature if present.
 * [opendkim.sig_getcanonlen()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getcanonlen()): get the canonicalized message length from the signature handle and message.
 * [opendkim.sig_getdomain()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()): get the domain from the signature handle.
 * [opendkim.sig_geterror()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()): Retrieve the error code associated with a rejected/disqualified signature.

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,11 @@ function verify(message, callback) {
 ## API Signing
 * [opendkim.sign()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sign()): get ready to sign a message.
 
+## API Utility
+* [opendkim.query_info()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.query_info()): get/set query info.
+* [opendkim.query_method()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.query_method()): get/set query method.
+* [opendkim.tmpdir()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.tmpdir()): get/set tmp dir.
+
 ## API Verifying
 * [opendkim.verify()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.verify()): get ready to verify a message.
 * [opendkim.get_signature()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.get_signature()): sets the signature info handle.
@@ -145,11 +150,6 @@ function verify(message, callback) {
 * [opendkim.sig_geterrorstr()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()): get the error string specified by the error code.
 * [opendkim.sig_getselector()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()): get the selector from the signature handle.
 * [opendkim.sig_getcanonlen()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getcanonlen()): get the canonicalized message length from the signature handle and message.
-
-## API Utility
-* [opendkim.query_info()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.query_info()): get/set query info.
-* [opendkim.query_method()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.query_method()): get/set query method.
-* [opendkim.tmpdir()](https://github.com/godsflaw/node-opendkim/wiki/opendkim.tmpdir()): get/set tmp dir.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -39,36 +39,82 @@ node-gyp rebuild
 
 ## Usage
 
-### Verify
+### Verify (async/await)
 
 ```js
 const OpenDKIM = require('node-opendkim');
 
-try {
+async function verify(message) {
   var opendkim = new OpenDKIM();
-  opendkim.verify({
-    id: undefined // optional (default: undefined)
-  });
 
-  // Adding one header at a time, when finished call opendkim.eoh()
-  var header = 'From: <herp@derp.com>';
-  opendkim.header({
-      header: header,
-      length: header.length
-  });
-  opendkim.eoh();
+  try {
+    await opendkim.verify({id: undefined});
+    await opendkim.chunk({
+      message: message,
+      length: message.length
+    });
+    await opendkim.chunk_end();
+  } catch (err) {
+    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
+    console.log(err);
+  }
+}
+```
 
-  // Adding body chunks, when finished call opendkim.eom().  This too
-  // can take many chunks.  Do NOT include the terminating DOT.
- var body = 'this is a test';
-  opendkim.body({
-      body: body,
-      length: body.length
+### Verify (sync)
+
+```js
+const OpenDKIM = require('node-opendkim');
+
+function verify_sync(message) {
+  var opendkim = new OpenDKIM();
+
+  try {
+    opendkim.verify_sync({id: undefined});
+    opendkim.chunk_sync({
+      message: message,
+      length: message.length
+    });
+    opendkim.chunk_end_sync();
+  } catch (err) {
+    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
+    console.log(err);
+  }
+}
+```
+
+### Verify (errback)
+
+```js
+const OpenDKIM = require('node-opendkim');
+
+function verify(message, callback) {
+  var opendkim = new OpenDKIM();
+
+  opendkim.verify({id: undefined}, function (err, result) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+
+    opendkim.chunk({
+      message: message,
+      length: message.length
+    }, function (err, result) {
+      if (err) {
+        console.log(err);
+        return;
+      }
+
+      opendkim.chunk_end(function (err, result) {
+        if (err) {
+          console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
+          console.log(err);
+          return;
+        }
+      });
+    });
   });
-  // This does the final validation, and will throw an error if there is one.
-  opendkim.eom();
-} catch (err) {
-  console.log(err);
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -96,10 +96,12 @@ function verify(message, callback) {
       return callback(err, result);
     }
 
-    opendkim.chunk({
+    var options = {
       message: message,
       length: message.length
-    }, function (err, result) {
+    };
+
+    opendkim.chunk(options, function (err, result) {
       if (err) {
         return callback(err, result);
       }

--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,7 @@ function verify(message, callback) {
 
   opendkim.verify({id: undefined}, function (err, result) {
     if (err) {
-      console.log(err);
-      return;
+      return callback(err, result);
     }
 
     opendkim.chunk({
@@ -102,20 +101,30 @@ function verify(message, callback) {
       length: message.length
     }, function (err, result) {
       if (err) {
-        console.log(err);
-        return;
+        return callback(err, result);
       }
 
       opendkim.chunk_end(function (err, result) {
         if (err) {
           console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
-          console.log(err);
-          return;
+          return callback(err, result);
         }
+
+        return callback(err, result);
       });
     });
   });
 }
+
+verify(message, function (err, result) {
+  if (err) {
+    // handle error
+    console.log(err);
+    return;
+  }
+
+  // success
+});
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ async function verify(message) {
     });
     await opendkim.chunk_end();
   } catch (err) {
-    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
+    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()));
     console.log(err);
   }
 }
@@ -77,7 +77,7 @@ function verify_sync(message) {
     });
     opendkim.chunk_end_sync();
   } catch (err) {
-    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
+    console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()));
     console.log(err);
   }
 }
@@ -88,9 +88,7 @@ function verify_sync(message) {
 ```js
 const OpenDKIM = require('node-opendkim');
 
-function verify(message, callback) {
-  var opendkim = new OpenDKIM();
-
+function verify(opendkim, message, callback) {
   opendkim.verify({id: undefined}, function (err, result) {
     if (err) {
       return callback(err, result);
@@ -108,7 +106,6 @@ function verify(message, callback) {
 
       opendkim.chunk_end(function (err, result) {
         if (err) {
-          console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()););
           return callback(err, result);
         }
 
@@ -118,11 +115,11 @@ function verify(message, callback) {
   });
 }
 
-verify(message, function (err, result) {
+var opendkim = new OpenDKIM();
+
+verify(opendkim, message, function (err, result) {
   if (err) {
-    // handle error
-    console.log(err);
-    return;
+    return console.log(opendkim.sig_geterrorstr(opendkim.sig_geterror()));
   }
 
   // success

--- a/src/opendkim.cc
+++ b/src/opendkim.cc
@@ -142,7 +142,7 @@ NAN_METHOD(OpenDKIM::FlushCacheSync) {
   if (records != -1) {
     info.GetReturnValue().Set(Nan::New<v8::Integer>(records));
   } else {
-    info.GetReturnValue().Set(info.This());
+    info.GetReturnValue().Set(Nan::Undefined());
   }
 }
 

--- a/test/00-administration/03-flush-cache-sync.js
+++ b/test/00-administration/03-flush-cache-sync.js
@@ -5,7 +5,7 @@ var OpenDKIM = require('../../');
 test('test flush_cache_sync with no active cache', t => {
   try {
     var opendkim = new OpenDKIM();
-    t.deepEqual(opendkim.flush_cache_sync(), opendkim);
+    t.is(opendkim.flush_cache_sync(), undefined);
   } catch (err) {
     t.fail(err.message);
   }

--- a/test/04-verifying/26-sig-getdomain.js
+++ b/test/04-verifying/26-sig-getdomain.js
@@ -30,8 +30,8 @@ test('test sig_getdomain before chunk_end', async t => {
       length: messages.good.length
     });
 
-    var identity = opendkim.sig_getdomain();
-    t.is(identity, 'example.com');
+    var domain = opendkim.sig_getdomain();
+    t.is(domain, 'example.com');
     t.fail();
   } catch (err) {
     t.is(
@@ -54,8 +54,8 @@ test('test sig_getdomain after chunk', async t => {
       length: messages.good.length
     });
     await opendkim.chunk_end();
-    var identity = opendkim.sig_getdomain();
-    t.is(identity, 'example.com');
+    var domain = opendkim.sig_getdomain();
+    t.is(domain, 'example.com');
   } catch (err) {
     console.log(err);
     var error = opendkim.sig_geterrorstr(opendkim.sig_geterror());
@@ -78,8 +78,8 @@ test('test a more pedantic sig_getdomain', async t => {
     });
     await opendkim.chunk_end();
     opendkim.get_signature();
-    var identity = opendkim.sig_getdomain();
-    t.is(identity, 'example.com');
+    var domain = opendkim.sig_getdomain();
+    t.is(domain, 'example.com');
   } catch (err) {
     console.log(err);
     var error = opendkim.sig_geterrorstr(opendkim.sig_geterror());

--- a/test/04-verifying/27-sig-getselector.js
+++ b/test/04-verifying/27-sig-getselector.js
@@ -30,8 +30,8 @@ test('test sig_getselector before chunk_end', async t => {
       length: messages.good.length
     });
 
-    var identity = opendkim.sig_getselector();
-    t.is(identity, 'test');
+    var selector = opendkim.sig_getselector();
+    t.is(selector, 'test');
     t.fail();
   } catch (err) {
     t.is(
@@ -54,8 +54,8 @@ test('test sig_getselector after chunk', async t => {
       length: messages.good.length
     });
     await opendkim.chunk_end();
-    var identity = opendkim.sig_getselector();
-    t.is(identity, 'test');
+    var selector = opendkim.sig_getselector();
+    t.is(selector, 'test');
   } catch (err) {
     console.log(err);
     t.fail();
@@ -76,8 +76,8 @@ test('test a more pedantic sig_getselector', async t => {
     });
     await opendkim.chunk_end();
     opendkim.get_signature();
-    var identity = opendkim.sig_getselector();
-    t.is(identity, 'test');
+    var selector = opendkim.sig_getselector();
+    t.is(selector, 'test');
   } catch (err) {
     console.log(err);
     t.fail();


### PR DESCRIPTION
# Description

Version bumps to `0.1.0` since the interface changed for async calls, and added some updated documentation.

# Contribution Checklist

- [x] first commit title starts with 'ISSUE-67:'
- [x] `opendkim.ohdrs()` code changes approved
- [x] `opendkim.flush_cache_sync()` code changes approved
- [x] code in `readme.md` approved
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.flush_cache()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.header()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.eoh()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.body()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.eom()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.chunk_end()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sign()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.verify()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.ohdrs()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getcanonlen()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getdomain()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterror()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_geterrorstr()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getidentity()
- [x] https://github.com/godsflaw/node-opendkim/wiki/opendkim.sig_getselector()
- [x] fixes #67
- [x] tagged and signed as `0.1.0` after pushed to dev
- [x] deployed to npm

### Link to gist documentation (will be manually added to the wiki)
https://github.com/godsflaw/node-opendkim/wiki